### PR TITLE
➕ Fix issue on v 14.0 that cause module to raise an error when instal…

### DIFF
--- a/data/account_chart_template_data.xml
+++ b/data/account_chart_template_data.xml
@@ -70,7 +70,7 @@
             ]"/>
         </record>
 
-        <function model="account.chart.template" name="try_loading_for_current_company">
+        <function model="account.chart.template" name="try_loading">
             <value eval="[ref('l10n_sv.cuentas_plantilla')]"/>
         </function>
     </data>


### PR DESCRIPTION
On v 14.0 of Odoo, this module causes an error, as most recent commits of odoo doesnt have the replaced function with that name, the way we do this now, has the same behaviour, and works with latest version of Odoo